### PR TITLE
Add Contributor badges to Rosie and Mafu

### DIFF
--- a/519760564755365888.json
+++ b/519760564755365888.json
@@ -1,0 +1,1 @@
+["contributor"]

--- a/581573474296791211.json
+++ b/581573474296791211.json
@@ -1,0 +1,1 @@
+["contributor"]


### PR DESCRIPTION
This PR simply adds the contributor badge to Rosie (acquite#0001, 581573474296791211) and Mafu (chinponta#7668, 519760564755365888) as we have had the Contributor role inside of the server for quite a while and I thought I might aswell PR the badges 🤷🏼‍♀️ 